### PR TITLE
Restore displaying of "Copy to clipboard" icon

### DIFF
--- a/supplemental-ui/partials/footer-scripts.hbs
+++ b/supplemental-ui/partials/footer-scripts.hbs
@@ -1,4 +1,4 @@
-<script src="{{uiRootPath}}/js/site.js"></script>
+<script id="site-script" src="{{{uiRootPath}}}/js/site.js" data-ui-root-path="{{{uiRootPath}}}"></script>
 {{#if env.SITE_SEARCH_PROVIDER}}
   {{> search-scripts}}
 {{/if}}


### PR DESCRIPTION
Fixes #28

The root cause of the issue: https://gitlab.com/antora/antora-ui-default/-/commit/02bd7175d71e9d9f0564411bd8d4091d43dd5fb5