### PR TITLE
[WIP]Play with validation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
         GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
       run: |
         npm i -g @antora/cli@3.1.2 @antora/site-generator@3.1.2 @antora/lunr-extension@1.0.0-alpha.8
-        antora ./antora-playbook.yml
+        antora --log-failure-level=warn ./antora-playbook.yml
 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
As of Antora 3, the Antora Xref Validator project is obsolete and its development has been halted. The xref validation for all resource types is now performed (properly) while Antora is generating the site. If there are xref validation errors, you can configure Antora to exit with a non-zero exit code by setting the [log failure level](https://docs.antora.org/antora/latest/playbook/runtime-log-failure-level/#failure-level-option) to ERROR (or WARN) (e.g., `--log-failure-level=error`). If you want Antora to stop immediately after xref validation is performed, you could write an Antora extension that calls `GeneratorContext#stop()` in the `documentsConverted` event.As of Antora 3, the Antora Xref Validator project is obsolete and its development has been halted.
The xref validation for all resource types is now performed (properly) while Antora is generating the site.
If there are xref validation errors, you can configure Antora to exit with a non-zero exit code by setting the [log failure level](https://docs.antora.org/antora/latest/playbook/runtime-log-failure-level/#failure-level-option) to ERROR (or WARN) (e.g., --log-failure-level=error).
If you want Antora to stop immediately after xref validation is performed, you could write an Antora extension that calls GeneratorContext#stop() in the documentsConverted event.