### PR TITLE
Bump Antora from `3.1.12` to `3.1.14`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       env:
         GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
       run: |
-        npm i -g @antora/cli@3.1.12 @antora/site-generator@3.1.12 @antora/lunr-extension@1.0.0-alpha.10
+        npm i -g @antora/cli@3.1.14 @antora/site-generator@3.1.14 @antora/lunr-extension@1.0.0-alpha.10
         npm i @asciidoctor/tabs@1.0.0-beta.6
         ln -s "$(pwd)/node_modules/@asciidoctor/tabs/dist/js/tabs.js" supplemental-ui/js/vendor/tabs.js
         ln -s "$(pwd)/node_modules/@asciidoctor/tabs/dist/css/tabs.css" supplemental-ui/css/vendor/tabs.css

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We use
 1. Install Node.js
 1. Install Antora and [Antora Lunr Extension](https://gitlab.com/antora/antora-lunr-extension)
     ```shell
-    npm i -g @antora/cli@3.1.12 @antora/site-generator@3.1.12 @antora/lunr-extension@1.0.0-alpha.10
+    npm i -g @antora/cli@3.1.14 @antora/site-generator@3.1.14 @antora/lunr-extension@1.0.0-alpha.10
     ```
 1. Install and configure an Asciidoctor.js extension that adds a tabs block to the AsciiDoc syntax.
     ```shell
@@ -28,7 +28,7 @@ We use
 
 ### One liner
 ```shell
- npm i -g @antora/cli@3.1.12 @antora/site-generator@3.1.12 @antora/lunr-extension@1.0.0-alpha.10 && \
+ npm i -g @antora/cli@3.1.14 @antora/site-generator@3.1.14 @antora/lunr-extension@1.0.0-alpha.10 && \
  git clone https://github.com/vividus-framework/vividus.git && \   
  git clone https://github.com/vividus-framework/docs.vividus.dev.git && \   
  cd docs.vividus.dev && \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Antora suite packages from version 3.1.12 to 3.1.14 in build configuration and documentation setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->